### PR TITLE
Install `"php" + php__version` to make package dependencies work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@ Added
 
 - :envvar:`php__dependent_configuration`. [ypid_]
 
+Fixed
+~~~~~
+
+- Ensure that the ``"php" + php__version`` package is installed so that
+  packages with alternative package dependencies work correctly. [ypid_]
+
 
 `debops.php v0.2.3`_ - 2016-08-09
 ---------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,7 +85,7 @@ php__server_api_packages: [ 'cli', 'fpm' ]
 # .. envvar:: php__base_packages [[[
 #
 # Install set of standard PHP packages.
-php__base_packages: [ 'curl', 'gd', 'mcrypt' ]
+php__base_packages: [ '{{ "php" + php__version }}', 'curl', 'gd', 'mcrypt' ]
 
                                                                    # ]]]
 # .. envvar:: php__packages [[[

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Install PHP packages
   apt:
-    name: '{{ item|search("php.*-")|ternary(item, "php" + php__version + "-" + item) }}'
+    name: '{{ item|match("php")|ternary(item, "php" + php__version + "-" + item) }}'
     state: 'present'
     install_recommends: False
   with_flattened:


### PR DESCRIPTION
Tested on: Debian Jessie
Tested on: Ubuntu Trusty
