### PR TITLE
Fix issue with empty strings in available_packages

### DIFF
--- a/files/script/php-filter-packages.sh
+++ b/files/script/php-filter-packages.sh
@@ -48,10 +48,8 @@ for element in ${search_packages[@]} ; do
         echo "${element}${php_version}"
 
     # Support for other packages
-    else
-        if [ -n "${element}" ] ; then
-            echo "${element}"
-        fi
+    elif [ -z "${element// }" ] ; then
+        echo "${element}"
     fi
 
 done


### PR DESCRIPTION
Pretty sure, this is the issue with #17. You only do a null check on `${element}`. I changed it to an empty string check based on this [stack overflow answer](https://unix.stackexchange.com/questions/146942/how-can-i-test-if-a-variable-is-empty-or-contains-only-spaces). (My bash skills aren't very good lol)