### PR TITLE
Revert "`always_run` is deprecated"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   script: 'script/php-filter-packages.sh {{ php__combined_packages }}'
   register: php__register_filtered_packages
   changed_when: False
-  check_mode: no
+  always_run: True
 
 - name: Install PHP packages
   apt:
@@ -99,7 +99,7 @@
     LC_ALL: 'C'
   shell: dpkg-divert --list '{{ php__etc_base + "/fpm/*" }}' | awk '{print $NF}'
   register: php__register_diversions
-  check_mode: no
+  always_run: True
   changed_when: False
 
 - name: Divert default PHP-FPM configuration and pool


### PR DESCRIPTION
This reverts commit cafda8dab9c09b91112b7a5fa6698cf896413257.

As discussed https://github.com/debops/ansible-php/pull/20 we want to retain compatibility with Ansible 2.1.
Edit: Tried to fix a typo in the commit message and rewrote the commit, thats why the test failed. Merge commit passed so don’t worry :wink: