### PR TITLE
Revert cafda8dab9c09b91112b7a5fa6698cf896413257

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,10 @@
   script: 'script/php-filter-packages.sh {{ php__combined_packages }}'
   register: php__register_filtered_packages
   changed_when: False
-  check_mode: no
+  # For compatibility reasons, we keep using always_run.
+  # We'd like to use `check_mode: no`, but it's only available in Ansible 2.2.
+  # Once you update, don't forget to update the required Ansible version in meta/main.yml.
+  always_run: True
 
 - name: Install PHP packages
   apt:
@@ -99,7 +102,9 @@
     LC_ALL: 'C'
   shell: dpkg-divert --list '{{ php__etc_base + "/fpm/*" }}' | awk '{print $NF}'
   register: php__register_diversions
-  check_mode: no
+  # See comment about compatibility above
+  # check_mode: no
+  always_run: True
   changed_when: False
 
 - name: Divert default PHP-FPM configuration and pool


### PR DESCRIPTION
check_mode only exists with Ansible 2.2.
Ubuntu currently ships Ansible 2.0.
We try to maintain compatibility for a while.