### PR TITLE
Allow reloading the 'php-fpm' service for specific UNIX group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.php master: https://github.com/debops/ansible-php/compare/v0.2.4...master
 
+Added
+~~~~~
+
+- Allow the ``webadmins`` UNIX system group to reload the ``php-fpm`` service
+  if needed using ``sudo``. [carlalexander, drybjed_]
+
 Changed
 ~~~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -285,6 +285,12 @@ php__dependent_configuration: []
 # Global PHP-FPM configuration [[[
 # --------------------------------
 
+# .. envvar:: php__fpm_privileged_group [[[
+#
+# What system group has privileged access to :program:`php-fpm` service.
+php__fpm_privileged_group: 'webadmins'
+
+                                                                   # ]]]
 # .. envvar:: php__fpm_syslog [[[
 #
 # Enable or disable error logging to ``syslog``. Currently the ``syslog``

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,14 @@
     - '{{ php__etc_base }}/ansible'
     - '{{ php__etc_base }}/fpm/pool.d'
 
+- name: Allow webadmins to reload php-fpm using sudo
+  template:
+    src: 'etc/sudoers.d/php-fpm_webadmins.j2'
+    dest: '/etc/sudoers.d/php-fpm_webadmins'
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+
                                                                    # ]]]
 # php.ini management [[[
 

--- a/templates/etc/sudoers.d/php-fpm_webadmins.j2
+++ b/templates/etc/sudoers.d/php-fpm_webadmins.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+Cmnd_Alias PHP_FPM_RELOAD = /etc/init.d/php{{ php__version }}-fpm reload, systemctl reload php{{ php__version }}-fpm.service
+
+%{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_RELOAD

--- a/templates/etc/sudoers.d/php-fpm_webadmins.j2
+++ b/templates/etc/sudoers.d/php-fpm_webadmins.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
-Cmnd_Alias PHP_FPM_RELOAD = /etc/init.d/php{{ php__version }}-fpm reload, systemctl reload php{{ php__version }}-fpm.service
+Cmnd_Alias PHP_FPM_RELOAD = /etc/init.d/php{{ php__version }}-fpm reload, \
+                            /bin/systemctl reload php{{ php__version }}-fpm.service
 
 %{{ php__fpm_privileged_group }} ALL = (root) NOPASSWD: PHP_FPM_RELOAD


### PR DESCRIPTION
Fixes #27 