### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.php v0.2.6`_ - 2017-02-21

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.php v0.2.6`_ - 2017-02-21

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.php master: https://github.com/debops/ansible-php/compare/v0.2.6...master
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.php v0.2.6`_ - 2017-02-21
 ---------------------------------

--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -39,7 +39,7 @@
     LC_ALL: 'C'
   shell: apt-cache show {{ php__version_preference | join(' ') }} | grep -E '^Package:\s+php' | head -n 1 | awk '{print $2}' | sed -e 's/^php//'
   register: php__register_version
-  always_run: True
+  check_mode: no
   changed_when: False
   tags: [ 'role::php:pools', 'role::php:config' ]
 
@@ -48,7 +48,7 @@
     LC_ALL: 'C'
   shell: apt-cache policy {{ php__version_preference | join(' ') }} | grep -E '^\s+Candidate:\s+' | grep --invert-match 'none' | head -n 1 | sed --regexp-extended 's/\s*[[:alnum:]]+:\s* ([^+-]+).*/\1/g;'
   register: php__register_long_version
-  always_run: True
+  check_mode: no
   changed_when: False
   tags: [ 'role::php:pools', 'role::php:config' ]
 

--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -39,7 +39,7 @@
     LC_ALL: 'C'
   shell: apt-cache show {{ php__version_preference | join(' ') }} | grep -E '^Package:\s+php' | head -n 1 | awk '{print $2}' | sed -e 's/^php//'
   register: php__register_version
-  check_mode: no
+  check_mode: False
   changed_when: False
   tags: [ 'role::php:pools', 'role::php:config' ]
 
@@ -48,7 +48,7 @@
     LC_ALL: 'C'
   shell: apt-cache policy {{ php__version_preference | join(' ') }} | grep -E '^\s+Candidate:\s+' | grep --invert-match 'none' | head -n 1 | sed --regexp-extended 's/\s*[[:alnum:]]+:\s* ([^+-]+).*/\1/g;'
   register: php__register_long_version
-  check_mode: no
+  check_mode: False
   changed_when: False
   tags: [ 'role::php:pools', 'role::php:config' ]
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Install and manage PHP environment'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '2.1.4'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.