### PR TITLE
Add filter for commonly bundled PHP packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 
-sudo: True
+sudo: required
+dist: trusty
 language: 'python'
 python: '2.7'
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,14 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.php master: https://github.com/debops/ansible-php/compare/v0.2.6...master
 
+Added
+~~~~~
+
+- Introduce :envvar:`php__included_packages` and enable filtering of PHP
+  packages which are shipped with the ``php-common`` APT package. The
+  variable is already defined according to the PHP packages shipped with
+  the supported distribution releases. [ganto_]
+
 Fixed
 ~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,13 +116,14 @@ php__dependent_packages: []
 #
 # List of all PHP packages requested for installation passed to the filter
 # script as a string of arguments for further processing.
-php__combined_packages: '{{ lookup("flattened",
-                            php__server_api_packages
-                            + php__base_packages
-                            + php__packages
-                            + php__group_packages
-                            + php__host_packages
-                            + php__dependent_packages).split(",")
+php__combined_packages: '{{ (lookup("flattened",
+                             php__server_api_packages
+                             + php__base_packages
+                             + php__packages
+                             + php__group_packages
+                             + php__host_packages
+                             + php__dependent_packages).split(",")
+                            | difference(php__included_packages))
                             | join(" ") }}'
 
                                                                    # ]]]
@@ -159,43 +160,8 @@ php__release_included_map:
 # .. envvar:: php__php5_included_packages [[[
 #
 # PHP packages usually part of the php5/php5-common packaging.
-php__php5_included_packages:
-  - 'bcmath'
-  - 'bz2'
-  - 'calendar'
-  - 'ctype'
-  - 'date'
-  - 'dba'
-  - 'dom'
-  - 'ereg'
-  - 'exif'
-  - 'fileinfo'
-  - 'filter'
-  - 'ftp'
-  - 'gettext'
-  - 'hash'
-  - 'iconv'
-  - 'libxml'
-  - 'mbstring'
-  - 'opcache'
-  - 'openssl'
-  - 'pcntl'
-  - 'pcre'
-  - 'pdo'
-  - 'session'
-  - 'shmop'
-  - 'simplexml'
-  - 'soap'
-  - 'sockets'
-  - 'spl'
-  - 'standard'
-  - 'sysvmsg'
-  - 'tokenizer'
-  - 'wddx'
-  - 'xml'
-  - 'xmlreader'
-  - 'xmlwriter'
-  - 'zip'
+php__php5_included_packages: '{{ php__php_included_packages + [ "mbstring", "zip" ] }}'
+
                                                                    # ]]]
 # .. envvar:: php__php_included_packages [[[
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -133,6 +133,109 @@ php__combined_packages: '{{ lookup("flattened",
 # Note that this option is not idempotent. It will reset on every role run.
 php__reset: False
                                                                    # ]]]
+# .. envvar:: php__included_packages [[[
+#
+# List of PHP packages which are shipped with the standard PHP distribution.
+# This variable is used to abstract packaging differences between different
+# PHP repositories or releases.
+php__included_packages: '{{ php__release_included_map[ansible_distribution_release] }}'
+
+                                                                   # ]]]
+# .. envvar:: php__release_included_map [[[
+#
+# Configuration dictionary mapping distribution releases to different PHP
+# packaging configurations. Also see :envvar:`php__included_packages`.
+php__release_included_map:
+  wheezy: '{{ php__php5_included_packages }}'
+  jessie: '{{ php__php5_included_packages }}'
+  stretch: '{{ php__php_included_packages }}'
+  buster: '{{ php__php_included_packages }}'
+  sid: '{{ php__php_included_packages }}'
+  trusty: '{{ php__php5_included_packages }}'
+  xenial: '{{ php__php_included_packages }}'
+  zesty: '{{ php__php_included_packages }}'
+
+                                                                   # ]]]
+# .. envvar:: php__php5_included_packages [[[
+#
+# PHP packages usually part of the php5/php5-common packaging.
+php__php5_included_packages:
+  - 'bcmath'
+  - 'bz2'
+  - 'calendar'
+  - 'ctype'
+  - 'date'
+  - 'dba'
+  - 'dom'
+  - 'ereg'
+  - 'exif'
+  - 'fileinfo'
+  - 'filter'
+  - 'ftp'
+  - 'gettext'
+  - 'hash'
+  - 'iconv'
+  - 'libxml'
+  - 'mbstring'
+  - 'opcache'
+  - 'openssl'
+  - 'pcntl'
+  - 'pcre'
+  - 'pdo'
+  - 'session'
+  - 'shmop'
+  - 'simplexml'
+  - 'soap'
+  - 'sockets'
+  - 'spl'
+  - 'standard'
+  - 'sysvmsg'
+  - 'tokenizer'
+  - 'wddx'
+  - 'xml'
+  - 'xmlreader'
+  - 'xmlwriter'
+  - 'zip'
+                                                                   # ]]]
+# .. envvar:: php__php_included_packages [[[
+#
+# PHP packages usually part of the php/php-common packaging.
+php__php_included_packages:
+  - 'bcmath'
+  - 'bz2'
+  - 'calendar'
+  - 'ctype'
+  - 'date'
+  - 'dba'
+  - 'dom'
+  - 'ereg'
+  - 'exif'
+  - 'fileinfo'
+  - 'filter'
+  - 'ftp'
+  - 'gettext'
+  - 'hash'
+  - 'iconv'
+  - 'libxml'
+  - 'opcache'
+  - 'openssl'
+  - 'pcntl'
+  - 'pcre'
+  - 'pdo'
+  - 'session'
+  - 'shmop'
+  - 'simplexml'
+  - 'soap'
+  - 'sockets'
+  - 'spl'
+  - 'standard'
+  - 'sysvmsg'
+  - 'tokenizer'
+  - 'wddx'
+  - 'xml'
+  - 'xmlreader'
+  - 'xmlwriter'
+                                                                   # ]]]
                                                                    # ]]]
 # Global php.ini configuration [[[
 # --------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,7 +140,9 @@ php__reset: False
 # This variable is used to abstract packaging differences between different
 # PHP repositories or releases. If you use a custom APT package for PHP,
 # you might need to adjust this list for proper package resolution.
-php__included_packages: '{{ php__release_included_map[ansible_distribution_release] }}'
+php__included_packages: '{{ php__php_included_packages
+                            if php__sury
+                            else php__release_included_map[ansible_distribution_release] }}'
 
                                                                    # ]]]
 # .. envvar:: php__release_included_map [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -138,7 +138,8 @@ php__reset: False
 #
 # List of PHP packages which are shipped with the standard PHP distribution.
 # This variable is used to abstract packaging differences between different
-# PHP repositories or releases.
+# PHP repositories or releases. If you use a custom APT package for PHP,
+# you might need to adjust this list for proper package resolution.
 php__included_packages: '{{ php__release_included_map[ansible_distribution_release] }}'
 
                                                                    # ]]]
@@ -160,21 +161,27 @@ php__release_included_map:
 # .. envvar:: php__php5_included_packages [[[
 #
 # PHP packages usually part of the php5/php5-common packaging.
-php__php5_included_packages: '{{ php__php_included_packages + [ "mbstring", "zip" ] }}'
+php__php5_included_packages: '{{ php__common_included_packages
+                                 + [ "bcmath", "bz2", "dba", "dom", "ereg",
+                                     "mbstring", "mhash", "SimpleXML", "soap",
+                                     "wddx", "xml", "xmlreader", "xmlwriter",
+                                     "zip" ] }}'
 
                                                                    # ]]]
 # .. envvar:: php__php_included_packages [[[
 #
+# PHP packages usually part of the php/php-common (PHP 7.x) packaging.
+php__php_included_packages: '{{ php__common_included_packages
+                                + [ "sysvsem", "sysvshm" ] }}'
+
+                                                                   # ]]]
+# .. envvar:: php__common_included_packages [[[
+#
 # PHP packages usually part of the php/php-common packaging.
-php__php_included_packages:
-  - 'bcmath'
-  - 'bz2'
+php__common_included_packages:
   - 'calendar'
   - 'ctype'
   - 'date'
-  - 'dba'
-  - 'dom'
-  - 'ereg'
   - 'exif'
   - 'fileinfo'
   - 'filter'
@@ -183,24 +190,21 @@ php__php_included_packages:
   - 'hash'
   - 'iconv'
   - 'libxml'
-  - 'opcache'
   - 'openssl'
   - 'pcntl'
   - 'pcre'
-  - 'pdo'
+  - 'PDO'
+  - 'Phar'
+  - 'posix'
+  - 'Reflection'
   - 'session'
   - 'shmop'
-  - 'simplexml'
-  - 'soap'
   - 'sockets'
-  - 'spl'
+  - 'SPL'
   - 'standard'
   - 'sysvmsg'
   - 'tokenizer'
-  - 'wddx'
-  - 'xml'
-  - 'xmlreader'
-  - 'xmlwriter'
+  - 'zlib'
                                                                    # ]]]
                                                                    # ]]]
 # Global php.ini configuration [[[

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
   environment:
     LC_ALL: 'C'
     PHP_VERSION: '{{ php__version }}'
-  script: 'script/php-filter-packages.sh {{ php__combined_packages | difference(php__included_packages) }}'
+  script: 'script/php-filter-packages.sh {{ php__combined_packages }}'
   register: php__register_filtered_packages
   changed_when: False
   check_mode: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
   environment:
     LC_ALL: 'C'
     PHP_VERSION: '{{ php__version }}'
-  script: 'script/php-filter-packages.sh {{ php__combined_packages }}'
+  script: 'script/php-filter-packages.sh {{ php__combined_packages | difference(php__included_packages) }}'
   register: php__register_filtered_packages
   changed_when: False
   check_mode: False


### PR DESCRIPTION
The PHP packaging between distributions and releases might slightly be different. For an example where this is an issue see #40.

This PR adds `php__included_packages` which takes a list of PHP packages included in the `php-common` APT package. It further pre-defines a list of included packages for the most commonly used distribution releases.

This change shouldn't affect any existing roles. However, after merging it might be possible to list the full PHP requirements in a consumer role no matter if it's packaged in the common package or a separate APT package. E.g. 
```
owncloud__required_php_packages:
  # Included in base install:
  # - 'ctype'
  # - 'dom'
  # - 'iconv'
  - 'gd'
  - 'json'
```
Can then be expressed as:
```
owncloud__required_php_packages:
  - 'ctype'
  - 'dom'
  - 'iconv'
  - 'gd'
  - 'json'
```

I'm not at all familiar with the PHP naming, but I somehow feel, that this PR is fuzzing the expression package which now can mean Debian package or PHP module(?). This is a bit unfortunate but clarifying this would mean a much larger change. What do you think?