### PR TITLE
Php installed from sury uses the same path as php7*

### DIFF
--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -68,16 +68,16 @@
 - name: Set PHP base paths
   set_fact:
     php__etc_base: '{{ ("/etc/php/" + php__version)
-                       if (php__version | version_compare("7.0", ">="))
+                       if (php__version | version_compare("7.0", ">=") or php__sury|bool)
                        else "/etc/php5" }}'
     php__lib_base: '{{ ("/usr/lib/php/" + php__version)
-                       if (php__version | version_compare("7.0", ">="))
+                       if (php__version | version_compare("7.0", ">=") or php__sury|bool)
                        else "/usr/lib/php5" }}'
     php__run_base: '{{ "/run/php"
-                       if (php__version | version_compare("7.0", ">="))
+                       if (php__version | version_compare("7.0", ">=") or php__sury|bool)
                        else "/run" }}'
     php__logrotate_lib_base: '{{ "/usr/lib/php"
-                                 if (php__version | version_compare("7.0", ">="))
+                                 if (php__version | version_compare("7.0", ">=") or php__sury|bool)
                                  else "/usr/lib/php5" }}'
   tags: [ 'role::php:pools', 'role::php:config' ]
 


### PR DESCRIPTION
I installed php5.6 on ubuntu 16 with the following configuration
```
php__version_preference: [ 'php5.6' ]
php__sury: True
```
The php configuration was installed in /etc/php/5.6
The calculated paths where expecting to be in /etc/php5 